### PR TITLE
Improve gulp watch and browser sync compatibility

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,16 +9,16 @@ pkg = require('./package.json'),
 // main directories
 dir = {
   base: __dirname + '/',
-  src: './src/',
-  dest: './build/',
-  vf: './node_modules/vanilla-framework/'
+  src: 'src/',
+  dest: 'build/',
+  vf: 'node_modules/vanilla-framework/'
 },
 
 // template config
 templateConfig = {
   engine:     'handlebars',
-  directory:  './src/templates/',
-  partials:   './src/partials/',
+  directory:  'src/templates/',
+  partials:   'src/partials/',
   default:    'default.hbt'
 },
 
@@ -63,14 +63,19 @@ gulp.task('help', function() {
 
 // Static server
 gulp.task('browser-sync', function() {
-    browserSync.init({
-        server: {
-            baseDir: "./build",
-            noOpen: true
-        }
-    });
+    var files = [
+        "build/**/*.css",
+        "build/**/*.html"
+    ];
 
-    gulp.watch("./build/**/*.html").on("change", reload);
+    browserSync.init(
+        files,
+        {
+            server: {
+                baseDir: "./build",
+                noOpen: true
+            }
+    });
 });
 
 /* Import docs from Vanilla Framework dep */


### PR DESCRIPTION
More reliably detect changes during watch, to local and upstream files.
Also use native browsersync functionality for watching changes.

# QA
 - Run `gulp develop`
- Modify template files, local sass, and remote sass files.
- Browsersync should update the browser page! 



PR for https://github.com/ubuntudesign/vanilla-framework/issues/490