### PR TITLE
remove forced capitalisation in side nav

### DIFF
--- a/scss/pattern-lib.scss
+++ b/scss/pattern-lib.scss
@@ -107,7 +107,6 @@ $sidebar-width: 12em;
     }
 
     &__link {
-      text-transform: capitalize;
       display: inline-block;
       margin-left: .5rem;
       font-size: .875rem;


### PR DESCRIPTION
### Done

Removed the forced Sentence Case capitalisation of the left menu items.

### QA

Run the site and check that the left nav items no longer are Sentence Case.

Fixes #14 