### PR TITLE
Add clean build step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /build/
 /node_modules/
 /src/docs/
+
+browsersync.local.json

--- a/browsersync.local.json.example
+++ b/browsersync.local.json.example
@@ -1,0 +1,5 @@
+{
+  "_": "https://www.browsersync.io/docs/options/",
+  "open": false,
+  "tunnel": "localtunnelsubdomain"
+}

--- a/browsersync.local.json.example
+++ b/browsersync.local.json.example
@@ -1,5 +1,5 @@
 {
   "_": "https://www.browsersync.io/docs/options/",
-  "open": false,
+  "open": true,
   "tunnel": "localtunnelsubdomain"
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,6 +48,7 @@ siteMeta = {
 // modules
 gulp = require('gulp'),
 rename = require('gulp-rename'),
+del = require('del'),
 sass = require('gulp-sass'),
 autoprefixer = require('gulp-autoprefixer'),
 gutil = require('gulp-util'),
@@ -60,6 +61,7 @@ browserSync = require('browser-sync').create(),
 reload      = browserSync.reload,
 ghPages = require('gulp-gh-pages'),
 plumber = require('gulp-plumber'),
+runSequence = require('run-sequence'),
 // Metalmsith - pattern library generation
 metalsmith = require('metalsmith'),
 markdown   = require('metalsmith-markdown'),
@@ -158,10 +160,27 @@ gulp.task('watch', function() {
   gulp.watch([dir.vf + 'docs/**/*.md', '*.md', 'partials/**/*.hbt', 'templates/**/*.hbt', 'pages/**/*.md'], ['pattern-library']);
 });
 
-gulp.task('develop', ['pattern-library', 'sass-develop', 'watch', 'browser-sync']);
+gulp.task('develop', ['clean'], function() {
+  runSequence(
+    ['pattern-library', 'sass-develop'],
+    'watch',
+    'browser-sync'
+)});
 
 gulp.task('test', ['sasslint']);
 
-gulp.task('build', ['pattern-library', 'sass-build']);
+gulp.task('build', ['clean'], function() {
+  runSequence(['pattern-library', 'sass-build']);
+});
+
+gulp.task('docs-clean', function() {
+  return del(['build/**/*.html']);
+});
+
+gulp.task('sass-clean', function() {
+  return del(['build/css/**/*.css']);
+});
+
+gulp.task('clean', ['sass-clean', 'docs-clean']);
 
 gulp.task('default', ['help']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,8 @@ dir = {
 
 browsersyncConfig = {
   server: {
-      baseDir: "./build"
+      baseDir: "./build",
+      open: false
   }
 },
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,10 +1,13 @@
 'use strict'
 
 var
+optional = require('optional'),
+
 // defaults
 consoleLog = false, // set true for metalsmith file and meta content logging
 devBuild = ((process.env.NODE_ENV || '').trim().toLowerCase() !== 'production'),
 pkg = require('./package.json'),
+bsLocalConfig = optional('./browsersync.local.json'),
 
 // main directories
 dir = {
@@ -13,6 +16,17 @@ dir = {
   dest: 'build/',
   vf: 'node_modules/vanilla-framework/'
 },
+
+browsersyncConfig = {
+  server: {
+      baseDir: "./build"
+  }
+},
+
+browsersyncFiles = [
+    "build/**/*.css",
+    "build/**/*.html"
+],
 
 // template config
 templateConfig = {
@@ -40,6 +54,7 @@ gutil = require('gulp-util'),
 scsslint = require('gulp-scss-lint'),
 cssnano = require('gulp-cssnano'),
 util = require('util'),
+extend = require('extend'),
 concat = require('gulp-concat'),
 browserSync = require('browser-sync').create(),
 reload      = browserSync.reload,
@@ -63,19 +78,8 @@ gulp.task('help', function() {
 
 // Static server
 gulp.task('browser-sync', function() {
-    var files = [
-        "build/**/*.css",
-        "build/**/*.html"
-    ];
-
-    browserSync.init(
-        files,
-        {
-            server: {
-                baseDir: "./build",
-                noOpen: true
-            }
-    });
+  extend(browsersyncConfig, bsLocalConfig);
+  browserSync.init(browsersyncFiles, browsersyncConfig);
 });
 
 /* Import docs from Vanilla Framework dep */

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "description": "Brochure and docs site for Vanilla Framework",
   "devDependencies": {
     "browser-sync": "^2.13.0",
+    "extend": "^3.0.0",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "3.1.0",
     "gulp-cache": "0.4.5",
@@ -32,6 +33,7 @@
     "metalsmith-partial": "^0.1.0",
     "metalsmith-permalinks": "^0.5.0",
     "metalsmith-templates": "^0.7.0",
+    "optional": "^0.1.3",
     "vanilla-framework": "1.0.0-alpha1"
   },
   "homepage": "http://vanillaframework.io",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
   "description": "Brochure and docs site for Vanilla Framework",
   "devDependencies": {
     "browser-sync": "^2.13.0",
+    "del": "^2.2.2",
     "extend": "^3.0.0",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "3.1.0",
     "gulp-cache": "0.4.5",
     "gulp-clean": "^0.3.2",
+    "gulp-clean-dest": "^0.1.1",
     "gulp-concat": "^2.6.0",
     "gulp-cssnano": "^2.1.2",
     "gulp-gh-pages": "^0.5.4",
@@ -34,6 +36,7 @@
     "metalsmith-permalinks": "^0.5.0",
     "metalsmith-templates": "^0.7.0",
     "optional": "^0.1.3",
+    "run-sequence": "^1.2.2",
     "vanilla-framework": "1.0.0-alpha1"
   },
   "homepage": "http://vanillaframework.io",


### PR DESCRIPTION
This PR should be reviewed after #41 
I will rebase if needed.

---

This PR:
- Adds a `clean` task and subtasks
- Runs clean before `build` or `develop` tasks
- Adds sequencing to run tasks in order
- Will hopefully stop BrowserSync opening a blank page!


I would really like to watch for deleted files and remove them on the fly but I need to look into that option more at a later time.