### PR TITLE
A script to run gulp through docker, mark 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /build/
-/node_modules/
 /src/docs/
-
 browsersync.local.json
+npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /src/docs/
 browsersync.local.json
 npm-debug.log
+.packages-volume-name

--- a/run
+++ b/run
@@ -1,0 +1,99 @@
+#! /usr/bin/env bash
+
+##
+# A script to install dependencies and run gulp inside docker-containers
+##
+
+# strict mode (http://redsymbol.net/articles/unofficial-bash-strict-mode/)
+set -euo pipefail
+
+# settings
+image_name="ubuntudesign/node:v1.0.7"
+volume_filename=".packages-volume-name"
+volume_name=
+commands=$@
+
+##
+# Check docker is installed correctly
+##
+if ! command -v docker >/dev/null 2>&1; then
+    echo "
+    Error: Docker not installed
+    ==
+    Please install Docker before continuing:
+    https://www.docker.com/products/docker
+    "
+fi
+if grep -q '^docker:' /etc/group && ! groups | grep -q '\bdocker\b'; then
+    echo "
+    Error: `whoami` not in docker group
+    ===
+    Please add this user to the docker group, e.g. with:
+    $$ newgrp docker
+    "
+fi
+
+while [[ -n "${1:-}" ]] && ( [[ "${1:0:1}" == "-" ]] || [[ "${1:0}" == "clean" ]] ); do
+    key="$1"
+
+    case $key in
+        -l|--local-override-module)
+            if [ -z "${2:-}" ]; then invalid; fi
+            override_paths+=("$2")
+            shift
+        ;;
+        -h|--help) commands="usage" ;;
+        clean)
+            containers_from_image=$(docker ps --all --quiet --filter "ancestor=$image_name")
+            containers_using_volume=$(docker ps --all --quiet --filter "volume=$volume_name")
+            # All containers, removing any duplicates
+            containers=$(echo "$containers_from_image $containers_using_volume" | xargs -n1 | sort -u | xargs)
+
+            if [ -n "$containers" ]; then
+                echo "Removing containers: $containers"
+                docker stop $containers
+                docker rm $containers
+            fi
+
+            if [ -n "$volume_name" ] && docker volume inspect $volume_name &> /dev/null; then
+                echo "Removing volume: $volume_name"
+                docker volume rm $volume_name
+            fi
+
+            if [ -f $volume_filename ]; then
+                echo "Removing $volume_filename"
+                rm $volume_filename
+            fi
+
+            exit
+        ;;
+        *)
+            echo "Command not recognised."
+            commands="usage"
+        ;;
+    esac
+
+    shift
+done
+
+if [ -n "${override_paths:-}" ]; then
+  overrides=""
+  for path in "${override_paths[@]}"; do
+    module_name=$(basename $path)
+    overrides+=" --volume '$path':/packages/overrides/$module_name"
+  done
+fi
+
+if [ ! -f .packages-volume-name ]; then
+  hash=$(uuidgen | sed 's/-//g' | cut -c1-8)
+  echo "node-packages-$hash" > $volume_filename
+fi
+
+volume_name=$(cat $volume_filename)
+
+docker run \
+  -ti \
+  --volume $volume_name:/packages/node_modules \
+  ${overrides:-} \
+  --volume `pwd`:/app \
+  $image_name $commands

--- a/run
+++ b/run
@@ -12,7 +12,6 @@ port=3000
 image_name="ubuntudesign/node:v1.0.7"
 volume_filename=".packages-volume-name"
 volume_name=
-commands=$@
 
 ##
 # Check docker is installed correctly
@@ -40,6 +39,7 @@ while [[ -n "${1:-}" ]] && ( [[ "${1:0:1}" == "-" ]] || [[ "${1:0}" == "clean" ]
     invalid() {
         echo "Command not recognised."
         commands="usage"
+        break
     }
 
     case $key in
@@ -81,11 +81,15 @@ while [[ -n "${1:-}" ]] && ( [[ "${1:0:1}" == "-" ]] || [[ "${1:0}" == "clean" ]
     shift
 done
 
+if [ -z "${commands:-}" ]; then
+    commands=$@
+fi
+
 if [ -n "${override_paths:-}" ]; then
   overrides=""
   for path in "${override_paths[@]}"; do
     module_name=$(basename $path)
-    overrides+=" --volume '$path':/packages/overrides/$module_name"
+    overrides+=" --volume $path:/packages/overrides/$module_name"
   done
 fi
 

--- a/run
+++ b/run
@@ -8,6 +8,7 @@
 set -euo pipefail
 
 # settings
+port=3000
 image_name="ubuntudesign/node:v1.0.7"
 volume_filename=".packages-volume-name"
 volume_name=
@@ -36,7 +37,17 @@ fi
 while [[ -n "${1:-}" ]] && ( [[ "${1:0:1}" == "-" ]] || [[ "${1:0}" == "clean" ]] ); do
     key="$1"
 
+    invalid() {
+        echo "Command not recognised."
+        commands="usage"
+    }
+
     case $key in
+        -p|--port)
+            if [ -z "${2:-}" ]; then invalid; fi
+            port="$2"
+            shift
+        ;;
         -l|--local-override-module)
             if [ -z "${2:-}" ]; then invalid; fi
             override_paths+=("$2")
@@ -44,10 +55,7 @@ while [[ -n "${1:-}" ]] && ( [[ "${1:0:1}" == "-" ]] || [[ "${1:0}" == "clean" ]
         ;;
         -h|--help) commands="usage" ;;
         clean)
-            containers_from_image=$(docker ps --all --quiet --filter "ancestor=$image_name")
-            containers_using_volume=$(docker ps --all --quiet --filter "volume=$volume_name")
-            # All containers, removing any duplicates
-            containers=$(echo "$containers_from_image $containers_using_volume" | xargs -n1 | sort -u | xargs)
+            containers=$(docker ps --all --quiet --filter "volume=$volume_name")
 
             if [ -n "$containers" ]; then
                 echo "Removing containers: $containers"
@@ -67,10 +75,7 @@ while [[ -n "${1:-}" ]] && ( [[ "${1:0:1}" == "-" ]] || [[ "${1:0}" == "clean" ]
 
             exit
         ;;
-        *)
-            echo "Command not recognised."
-            commands="usage"
-        ;;
+        *) invalid ;;
     esac
 
     shift
@@ -93,6 +98,7 @@ volume_name=$(cat $volume_filename)
 
 docker run \
   -ti \
+  -p $port:$port \
   --volume $volume_name:/packages/node_modules \
   ${overrides:-} \
   --volume `pwd`:/app \

--- a/run-gulp
+++ b/run-gulp
@@ -1,0 +1,7 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+docker run -ti --volume vfio-dependencies:/packages/node_modules --volume `pwd`:/app ubuntudesign/node:v1.0.2 gulp import-docs
+docker run -ti -p 3000:3000 --volume vfio-dependencies:/packages/node_modules --volume `pwd`:/app ubuntudesign/node:v1.0.2 gulp develop
+

--- a/run-gulp
+++ b/run-gulp
@@ -1,7 +1,0 @@
-#! /usr/bin/env bash
-
-set -euo pipefail
-
-docker run -ti --volume vfio-dependencies:/packages/node_modules --volume `pwd`:/app ubuntudesign/node:v1.0.2 gulp import-docs
-docker run -ti -p 3000:3000 --volume vfio-dependencies:/packages/node_modules --volume `pwd`:/app ubuntudesign/node:v1.0.2 gulp develop
-


### PR DESCRIPTION
Make use of [ubuntudesign/node:v1.0.7](https://hub.docker.com/r/ubuntudesign/node/) to build docs and run gulp in a nice simple encapsulated way.

This is sort of experimental. It occurred to me that ubuntudesign/node does give us a simple way to encapsulate node dependencies pretty easily. So this is just a sort of prototype for how to do that well.

I tried this before (#13) but it didn't work because `SASS_PATH` wasn't implemented in `node-sass`. I've now [fixed that](https://github.com/sass/node-sass/pull/1680).
## QA

``` bash
$ ./run gulp import-docs  # Setup dependencies and import documentation
$ ./run gulp develop      # Run the server
$ ./run usage             # Show instructions
```
