### PR TITLE
Clean docs folder before reimporting

### DIFF
--- a/gulp/tasks/metalsmith.js
+++ b/gulp/tasks/metalsmith.js
@@ -37,7 +37,11 @@
 
   module.exports = function(gulp, plugins) {
 
-    gulp.task('metalsmith:import-docs', function() {
+    gulp.task('metalsmith:clean-docs', function() {
+      return del(paths.import.docs)
+    });
+
+    gulp.task('metalsmith:import-docs', ['metalsmith:clean-docs'], function() {
       return gulp.src([paths.src.vfDocs]).pipe(gulp.dest(paths.import.docs));
     });
 


### PR DESCRIPTION
Add a task to delete the local docs cache, and require it to run before importing VF docs.

`gulp metalsmith:import-docs` should remove old files and import fresh files correctly.