### PR TITLE
Metalsmith do not delete build dir, and fix MD file watch

### DIFF
--- a/gulp/paths.js
+++ b/gulp/paths.js
@@ -15,7 +15,7 @@
       hbt: src + '/**/*.hbt',
       img: src + '/img/**/*',
       js: src + '/js/**/*.js',
-      md: src + '/src/**/*.md',
+      md: src + '/**/*.md',
       sass: 'scss/**/*.scss',
       vfDocs: vanillaFramework + '/docs/**/*.md',
       vfSass: 'scss/**/*.scss'

--- a/gulp/tasks/metalsmith.js
+++ b/gulp/tasks/metalsmith.js
@@ -51,8 +51,9 @@
           paths.metalsmith.source,
           paths.metalsmith.vfDocs
         )
-        .use(metalsmithFilter(filterConfig))
+        .clean(false)
         .destination(paths.metalsmith.destination)
+        .use(metalsmithFilter(filterConfig))
         .use(metalsmithCollections(collectionsConfig))
         .use(metalsmithMarkdown())
         .use(metalsmithPermalinks(permalinksConfig))


### PR DESCRIPTION
Do not lose the CSS when rebuilding metalsmith directly or while watching.

Also update the watch on local .md files.

Fixes #53 